### PR TITLE
Ensure composer dist archive contains only usefull files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,20 @@
         "test": [
             "XDEBUG_MODE=coverage phpunit"
         ]
+    },
+    "archive": {
+        "exclude": [
+            "/.github/",
+            "/demo/",
+            "/docs/",
+            "/tests/",
+            "/testsDependency/",
+            "/.gitignore",
+            "/logo.png",
+            "/multifactorauthforeveryone.png",
+            "/phpunit.xml",
+            "/TwoFactorAuth.phpproj",
+            "/TwoFactorAuth.sln"
+        ]
     }
 }


### PR DESCRIPTION
With proposed changes, Github configuration, demo, documentation and test files will no more be included in composer dist archives.

Package weight will decrease from 175kB to 62kB. This is not a big change, but your package is downloaded almost 4k per day, so on the long term, it can save lots of bandwidth.

Anyway, problem is not only related to bandwidth and disk usage. On a project I work on, we had in the past a severe security flaw (unauthenticated RCE) that was located in a demo file of a library we used. I do not think there is such a flaw in your demo/test files (I did not tried to find one), but now you know why I propose such a PR.